### PR TITLE
build: prevent lib/Buffer.php to be always autoloaded by Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
   "autoload": {
     "psr-4": {
       "BufferSDK\\": "lib/"
-    },
-    "files": ["lib/Buffer.php"]
+    }
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
Fix #2 